### PR TITLE
Change hospital id to medical records number

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Changelog
 
 1.0.0 (Unreleased)
 ------------------
-- #20 Change "Hospital ID" to "Medical Records Number"
+- #21 Change "Hospital ID" to "Medical Records Number"
 - #20 Compatibility with core#2692 (Refactor sticker functionality)
 - #18 Display patient 'Date of Birth' in sticker "Code 39 40x28mm" 
 - #16 Update results report heading to "Medical Laboratory Services"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Changelog
 
 1.0.0 (Unreleased)
 ------------------
-
+- #20 Change "Hospital ID" to "Medical Records Number"
 - #20 Compatibility with core#2692 (Refactor sticker functionality)
 - #18 Display patient 'Date of Birth' in sticker "Code 39 40x28mm" 
 - #16 Update results report heading to "Medical Laboratory Services"

--- a/src/bes/nauru/lims/impress/reports/Default.pt
+++ b/src/bes/nauru/lims/impress/reports/Default.pt
@@ -297,7 +297,7 @@
                 tal:content="python:model.PatientFullName"/>
 
             <!-- Patient Hospital Number -->
-            <td width="15%" class="label" i18n:translate="">Hospital Number</td>
+            <td width="15%" class="label" i18n:translate="">MRN #</td>
             <td width="20%" tal:content="model/MedicalRecordNumber/value|nothing"/>
 
             <!-- Patient sex -->

--- a/src/bes/nauru/lims/locales/bes.nauru.lims.pot
+++ b/src/bes/nauru/lims/locales/bes.nauru.lims.pot
@@ -168,8 +168,6 @@ msgstr ""
 
 #: bes.nauru.lims/src/bes/nauru/lims/browser/sample/templates/rejection_content.pt:99
 #: bes.nauru.lims/src/bes/nauru/lims/impress/reports/Default.pt:299
-msgid "Hospital Number"
-msgstr "MRN"
 
 #: bes.nauru.lims/src/bes/nauru/lims/browser/sample/templates/rejection_content.pt:127
 #: bes.nauru.lims/src/bes/nauru/lims/content/analysisrequest.py:79

--- a/src/bes/nauru/lims/locales/bes.nauru.lims.pot
+++ b/src/bes/nauru/lims/locales/bes.nauru.lims.pot
@@ -169,7 +169,7 @@ msgstr ""
 #: bes.nauru.lims/src/bes/nauru/lims/browser/sample/templates/rejection_content.pt:99
 #: bes.nauru.lims/src/bes/nauru/lims/impress/reports/Default.pt:299
 msgid "Hospital Number"
-msgstr ""
+msgstr "MRN"
 
 #: bes.nauru.lims/src/bes/nauru/lims/browser/sample/templates/rejection_content.pt:127
 #: bes.nauru.lims/src/bes/nauru/lims/content/analysisrequest.py:79

--- a/src/bes/nauru/lims/locales/en/LC_MESSAGES/bes.nauru.lims.po
+++ b/src/bes/nauru/lims/locales/en/LC_MESSAGES/bes.nauru.lims.po
@@ -166,7 +166,7 @@ msgstr ""
 #: bes/nauru/lims/browser/sample/templates/rejection_content.pt:99
 #: bes/nauru/lims/impress/reports/Default.pt:299
 msgid "Hospital Number"
-msgstr "MRN"
+msgstr ""
 
 #: bes/nauru/lims/browser/sample/templates/rejection_content.pt:127
 #: bes/nauru/lims/content/analysisrequest.py:79

--- a/src/bes/nauru/lims/locales/en/LC_MESSAGES/bes.nauru.lims.po
+++ b/src/bes/nauru/lims/locales/en/LC_MESSAGES/bes.nauru.lims.po
@@ -166,7 +166,7 @@ msgstr ""
 #: bes/nauru/lims/browser/sample/templates/rejection_content.pt:99
 #: bes/nauru/lims/impress/reports/Default.pt:299
 msgid "Hospital Number"
-msgstr ""
+msgstr "MRN"
 
 #: bes/nauru/lims/browser/sample/templates/rejection_content.pt:127
 #: bes/nauru/lims/content/analysisrequest.py:79

--- a/src/bes/nauru/lims/locales/en/LC_MESSAGES/senaite.patient.po
+++ b/src/bes/nauru/lims/locales/en/LC_MESSAGES/senaite.patient.po
@@ -16,74 +16,74 @@ msgstr ""
 
 #: senaite/patient/browser/controlpanel.py:219
 msgid "Allow to publish samples with a temporary MRN"
-msgstr "Allow to publish samples with a temporary Hospital Number"
+msgstr "Allow to publish samples with a temporary Medical Record Number (MRN)"
 
 #: senaite/patient/browser/controlpanel.py:210
 msgid "Allow to verify samples with a temporary MRN"
-msgstr "Allow to verify samples with a temporary Hospital Number"
+msgstr "Allow to verify samples with a temporary Medical Record Number (MRN)"
 
 #: senaite/patient/browser/controlpanel.py:228
 msgid "Display an alert icon on samples with a temporary MRN"
-msgstr "Display an alert icon on samples with a temporary Hospital Number"
+msgstr "Display an alert icon on samples with a temporary Medical Record Number (MRN)"
 
 #: senaite/patient/browser/controlpanel.py:220
 msgid "If selected, users will be able to publish samples that have a Patient assigned with a temporary Medical Record Number (MRN)."
-msgstr "If selected, users will be able to publish samples that have a Patient assigned with a temporary Hospital Number."
+msgstr "If selected, users will be able to publish samples that have a Patient assigned with a temporary Medical Record Number (MRN)."
 
 #: senaite/patient/browser/controlpanel.py:211
 msgid "If selected, users will be able to verify samples that have a Patient assigned with a temporary Medical Record Number (MRN)."
-msgstr "If selected, users will be able to verify samples that have a Patient assigned with a temporary Hospital Number."
+msgstr "If selected, users will be able to verify samples that have a Patient assigned with a temporary Medical Record Number (MRN)."
 
 #: senaite/patient/adapters/listing.py:59
 #: senaite/patient/content/analysisrequest.py:92
 msgid "MRN"
-msgstr "Hospital Number"
+msgstr "MRN"
 
 #: senaite/patient/browser/controlpanel.py:201
 msgid "Make the MRN field mandatory in the sample registration form and when creating or modifying patients."
-msgstr "Make the Hospital Number field mandatory in the sample registration form and when creating or modifying patients."
+msgstr "Make the Medical Record Number (MRN) field mandatory in the sample registration form and when creating or modifying patients."
 
 #: senaite/patient/browser/patientfolder.py:75
 #: senaite/patient/content/analysisrequest.py:66
 msgid "Medical Record #"
-msgstr "Hospital Number"
+msgstr "Medical Record #"
 
 #: senaite/patient/adapters/listing.py:131
 msgid "Patient MRN of sample is not equal to %s"
-msgstr "Patient Hospital Number of sample is not equal to %s"
+msgstr "Patient MRN of sample is not equal to %s"
 
 #: senaite/patient/content/patient.py:328
 msgid "Patient Medical Record # must be unique"
-msgstr "Patient Hospital Number must be unique"
+msgstr "Patient Medical Record Number (MRN) must be unique"
 
 #: senaite/patient/content/patient.py:109
 msgid "Patient Medical Record Number"
-msgstr "Patient Hospital Number"
+msgstr "Patient Medical Record Number"
 
 #: senaite/patient/content/patient.py:322
 msgid "Patient Medical Record is missing or empty"
-msgstr "Patient Hospital Number is missing or empty"
+msgstr "Patient Medical Record Number (MRN) is missing or empty"
 
 #: senaite/patient/browser/controlpanel.py:200
 msgid "Require Medical Record Number (MRN)"
-msgstr "Require Hospital Number"
+msgstr "Require Medical Record Number (MRN)"
 
 #: senaite/patient/adapters/listing.py:39
 msgid "Temporary MRN"
-msgstr "Temp Hospital Number"
+msgstr "Temp MRN"
 
 #: senaite/patient/browser/viewlets/templates/temporary_mrn_viewlet.pt:13
 msgid "The Medical Record Number (MRN) assigned to this sample is temporary"
-msgstr "The Hospital Number assigned to this sample is temporary"
+msgstr "The Medical Record Number (MRN) assigned to this sample is temporary"
 
 #: senaite/patient/browser/controlpanel.py:229
 msgid "When selected, an alert icon is displayed in samples listing for samples that have a Patient assigned with a temporary Medical Record Number (MRN)."
-msgstr "When selected, an alert icon is displayed in samples listing for samples that have a Patient assigned with a temporary Hospital Number."
+msgstr "When selected, an alert icon is displayed in samples listing for samples that have a Patient assigned with a temporary Medical Record Number (MRN)."
 
 #: senaite/patient/subscribers/analysisrequest.py:106
 msgid "You are not allowed to add a patient in {} folder. Medical Record Number set to Temporary."
-msgstr "You are not allowed to add a patient in {} folder. Hospital Number set to Temporary."
+msgstr "You are not allowed to add a patient in {} folder. Medical Record Number (MRN) set to Temporary."
 
 #: senaite/patient/content/patient.py:108
 msgid "label_patient_mrn"
-msgstr "Hospital Number"
+msgstr "Medical Record Number (MRN)"

--- a/src/bes/nauru/lims/locales/en/LC_MESSAGES/senaite.patient.po
+++ b/src/bes/nauru/lims/locales/en/LC_MESSAGES/senaite.patient.po
@@ -15,75 +15,39 @@ msgstr ""
 "Domain: DOMAIN\n"
 
 #: senaite/patient/browser/controlpanel.py:219
-msgid "Allow to publish samples with a temporary MRN"
-msgstr "Allow to publish samples with a temporary Medical Record Number (MRN)"
 
 #: senaite/patient/browser/controlpanel.py:210
-msgid "Allow to verify samples with a temporary MRN"
-msgstr "Allow to verify samples with a temporary Medical Record Number (MRN)"
 
 #: senaite/patient/browser/controlpanel.py:228
-msgid "Display an alert icon on samples with a temporary MRN"
-msgstr "Display an alert icon on samples with a temporary Medical Record Number (MRN)"
 
 #: senaite/patient/browser/controlpanel.py:220
-msgid "If selected, users will be able to publish samples that have a Patient assigned with a temporary Medical Record Number (MRN)."
-msgstr "If selected, users will be able to publish samples that have a Patient assigned with a temporary Medical Record Number (MRN)."
 
 #: senaite/patient/browser/controlpanel.py:211
-msgid "If selected, users will be able to verify samples that have a Patient assigned with a temporary Medical Record Number (MRN)."
-msgstr "If selected, users will be able to verify samples that have a Patient assigned with a temporary Medical Record Number (MRN)."
 
 #: senaite/patient/adapters/listing.py:59
 #: senaite/patient/content/analysisrequest.py:92
-msgid "MRN"
-msgstr "MRN"
 
 #: senaite/patient/browser/controlpanel.py:201
-msgid "Make the MRN field mandatory in the sample registration form and when creating or modifying patients."
-msgstr "Make the Medical Record Number (MRN) field mandatory in the sample registration form and when creating or modifying patients."
 
 #: senaite/patient/browser/patientfolder.py:75
 #: senaite/patient/content/analysisrequest.py:66
-msgid "Medical Record #"
-msgstr "Medical Record #"
 
 #: senaite/patient/adapters/listing.py:131
-msgid "Patient MRN of sample is not equal to %s"
-msgstr "Patient MRN of sample is not equal to %s"
 
 #: senaite/patient/content/patient.py:328
-msgid "Patient Medical Record # must be unique"
-msgstr "Patient Medical Record Number (MRN) must be unique"
 
 #: senaite/patient/content/patient.py:109
-msgid "Patient Medical Record Number"
-msgstr "Patient Medical Record Number"
 
 #: senaite/patient/content/patient.py:322
-msgid "Patient Medical Record is missing or empty"
-msgstr "Patient Medical Record Number (MRN) is missing or empty"
 
 #: senaite/patient/browser/controlpanel.py:200
-msgid "Require Medical Record Number (MRN)"
-msgstr "Require Medical Record Number (MRN)"
 
 #: senaite/patient/adapters/listing.py:39
-msgid "Temporary MRN"
-msgstr "Temp MRN"
 
 #: senaite/patient/browser/viewlets/templates/temporary_mrn_viewlet.pt:13
-msgid "The Medical Record Number (MRN) assigned to this sample is temporary"
-msgstr "The Medical Record Number (MRN) assigned to this sample is temporary"
 
 #: senaite/patient/browser/controlpanel.py:229
-msgid "When selected, an alert icon is displayed in samples listing for samples that have a Patient assigned with a temporary Medical Record Number (MRN)."
-msgstr "When selected, an alert icon is displayed in samples listing for samples that have a Patient assigned with a temporary Medical Record Number (MRN)."
 
 #: senaite/patient/subscribers/analysisrequest.py:106
-msgid "You are not allowed to add a patient in {} folder. Medical Record Number set to Temporary."
-msgstr "You are not allowed to add a patient in {} folder. Medical Record Number (MRN) set to Temporary."
 
 #: senaite/patient/content/patient.py:108
-msgid "label_patient_mrn"
-msgstr "Medical Record Number (MRN)"

--- a/src/bes/nauru/lims/locales/senaite.patient.pot
+++ b/src/bes/nauru/lims/locales/senaite.patient.pot
@@ -16,74 +16,74 @@ msgstr ""
 
 #: senaite/patient/browser/controlpanel.py:219
 msgid "Allow to publish samples with a temporary MRN"
-msgstr "Allow to publish samples with a temporary Hospital Number"
+msgstr "Allow to publish samples with a temporary Medical Record Number (MRN)"
 
 #: senaite/patient/browser/controlpanel.py:210
 msgid "Allow to verify samples with a temporary MRN"
-msgstr "Allow to verify samples with a temporary Hospital Number"
+msgstr "Allow to verify samples with a temporary Medical Record Number (MRN)"
 
 #: senaite/patient/browser/controlpanel.py:228
 msgid "Display an alert icon on samples with a temporary MRN"
-msgstr "Display an alert icon on samples with a temporary Hospital Number"
+msgstr "Display an alert icon on samples with a temporary Medical Record Number (MRN)"
 
 #: senaite/patient/browser/controlpanel.py:220
 msgid "If selected, users will be able to publish samples that have a Patient assigned with a temporary Medical Record Number (MRN)."
-msgstr "If selected, users will be able to publish samples that have a Patient assigned with a temporary Hospital Number."
+msgstr "If selected, users will be able to publish samples that have a Patient assigned with a temporary Medical Record Number (MRN)."
 
 #: senaite/patient/browser/controlpanel.py:211
 msgid "If selected, users will be able to verify samples that have a Patient assigned with a temporary Medical Record Number (MRN)."
-msgstr "If selected, users will be able to verify samples that have a Patient assigned with a temporary Hospital Number."
+msgstr "If selected, users will be able to verify samples that have a Patient assigned with a temporary Medical Record Number (MRN)."
 
 #: senaite/patient/adapters/listing.py:59
 #: senaite/patient/content/analysisrequest.py:92
 msgid "MRN"
-msgstr "Hospital Number"
+msgstr "MRN"
 
 #: senaite/patient/browser/controlpanel.py:201
 msgid "Make the MRN field mandatory in the sample registration form and when creating or modifying patients."
-msgstr "Make the Hospital Number field mandatory in the sample registration form and when creating or modifying patients."
+msgstr "Make the Medical Record Number (MRN) field mandatory in the sample registration form and when creating or modifying patients."
 
 #: senaite/patient/browser/patientfolder.py:75
 #: senaite/patient/content/analysisrequest.py:66
 msgid "Medical Record #"
-msgstr "Hospital Number"
+msgstr "Medical Record #"
 
 #: senaite/patient/adapters/listing.py:131
 msgid "Patient MRN of sample is not equal to %s"
-msgstr "Patient Hospital Number of sample is not equal to %s"
+msgstr "Patient Medical Record Number (MRN) of sample is not equal to %s"
 
 #: senaite/patient/content/patient.py:328
 msgid "Patient Medical Record # must be unique"
-msgstr "Patient Hospital Number must be unique"
+msgstr "Patient Medical Record Number (MRN) must be unique"
 
 #: senaite/patient/content/patient.py:109
 msgid "Patient Medical Record Number"
-msgstr "Patient Hospital Number"
+msgstr "Patient Medical Record Number (MRN)"
 
 #: senaite/patient/content/patient.py:322
 msgid "Patient Medical Record is missing or empty"
-msgstr "Patient Hospital Number is missing or empty"
+msgstr "Patient Medical Record Number (MRN) is missing or empty"
 
 #: senaite/patient/browser/controlpanel.py:200
 msgid "Require Medical Record Number (MRN)"
-msgstr "Require Hospital Number"
+msgstr "Require Medical Record Number (MRN)"
 
 #: senaite/patient/adapters/listing.py:39
 msgid "Temporary MRN"
-msgstr "Temp Hospital Number"
+msgstr "Temp MRN"
 
 #: senaite/patient/browser/viewlets/templates/temporary_mrn_viewlet.pt:13
 msgid "The Medical Record Number (MRN) assigned to this sample is temporary"
-msgstr "The Hospital Number assigned to this sample is temporary"
+msgstr "The Medical Record Number (MRN) assigned to this sample is temporary"
 
 #: senaite/patient/browser/controlpanel.py:229
 msgid "When selected, an alert icon is displayed in samples listing for samples that have a Patient assigned with a temporary Medical Record Number (MRN)."
-msgstr "When selected, an alert icon is displayed in samples listing for samples that have a Patient assigned with a temporary Hospital Number."
+msgstr "When selected, an alert icon is displayed in samples listing for samples that have a Patient assigned with a temporary Medical Record Number (MRN)."
 
 #: senaite/patient/subscribers/analysisrequest.py:106
 msgid "You are not allowed to add a patient in {} folder. Medical Record Number set to Temporary."
-msgstr "You are not allowed to add a patient in {} folder. Hospital Number set to Temporary."
+msgstr "You are not allowed to add a patient in {} folder. Medical Record Number (MRN) set to Temporary."
 
 #: senaite/patient/content/patient.py:108
 msgid "label_patient_mrn"
-msgstr "Hospital Number"
+msgstr "MRN"

--- a/src/bes/nauru/lims/locales/senaite.patient.pot
+++ b/src/bes/nauru/lims/locales/senaite.patient.pot
@@ -15,74 +15,41 @@ msgstr ""
 "Domain: DOMAIN\n"
 
 #: senaite/patient/browser/controlpanel.py:219
-msgid "Allow to publish samples with a temporary MRN"
-msgstr "Allow to publish samples with a temporary Medical Record Number (MRN)"
 
 #: senaite/patient/browser/controlpanel.py:210
-msgid "Allow to verify samples with a temporary MRN"
-msgstr "Allow to verify samples with a temporary Medical Record Number (MRN)"
 
 #: senaite/patient/browser/controlpanel.py:228
-msgid "Display an alert icon on samples with a temporary MRN"
-msgstr "Display an alert icon on samples with a temporary Medical Record Number (MRN)"
 
 #: senaite/patient/browser/controlpanel.py:220
-msgid "If selected, users will be able to publish samples that have a Patient assigned with a temporary Medical Record Number (MRN)."
-msgstr "If selected, users will be able to publish samples that have a Patient assigned with a temporary Medical Record Number (MRN)."
 
 #: senaite/patient/browser/controlpanel.py:211
-msgid "If selected, users will be able to verify samples that have a Patient assigned with a temporary Medical Record Number (MRN)."
-msgstr "If selected, users will be able to verify samples that have a Patient assigned with a temporary Medical Record Number (MRN)."
 
 #: senaite/patient/adapters/listing.py:59
 #: senaite/patient/content/analysisrequest.py:92
-msgid "MRN"
-msgstr "MRN"
 
 #: senaite/patient/browser/controlpanel.py:201
-msgid "Make the MRN field mandatory in the sample registration form and when creating or modifying patients."
-msgstr "Make the Medical Record Number (MRN) field mandatory in the sample registration form and when creating or modifying patients."
 
 #: senaite/patient/browser/patientfolder.py:75
 #: senaite/patient/content/analysisrequest.py:66
-msgid "Medical Record #"
-msgstr "Medical Record #"
 
 #: senaite/patient/adapters/listing.py:131
-msgid "Patient MRN of sample is not equal to %s"
-msgstr "Patient Medical Record Number (MRN) of sample is not equal to %s"
 
 #: senaite/patient/content/patient.py:328
-msgid "Patient Medical Record # must be unique"
-msgstr "Patient Medical Record Number (MRN) must be unique"
 
 #: senaite/patient/content/patient.py:109
-msgid "Patient Medical Record Number"
-msgstr "Patient Medical Record Number (MRN)"
 
 #: senaite/patient/content/patient.py:322
-msgid "Patient Medical Record is missing or empty"
-msgstr "Patient Medical Record Number (MRN) is missing or empty"
 
 #: senaite/patient/browser/controlpanel.py:200
-msgid "Require Medical Record Number (MRN)"
-msgstr "Require Medical Record Number (MRN)"
 
 #: senaite/patient/adapters/listing.py:39
-msgid "Temporary MRN"
-msgstr "Temp MRN"
 
 #: senaite/patient/browser/viewlets/templates/temporary_mrn_viewlet.pt:13
-msgid "The Medical Record Number (MRN) assigned to this sample is temporary"
-msgstr "The Medical Record Number (MRN) assigned to this sample is temporary"
 
 #: senaite/patient/browser/controlpanel.py:229
-msgid "When selected, an alert icon is displayed in samples listing for samples that have a Patient assigned with a temporary Medical Record Number (MRN)."
-msgstr "When selected, an alert icon is displayed in samples listing for samples that have a Patient assigned with a temporary Medical Record Number (MRN)."
 
 #: senaite/patient/subscribers/analysisrequest.py:106
-msgid "You are not allowed to add a patient in {} folder. Medical Record Number set to Temporary."
-msgstr "You are not allowed to add a patient in {} folder. Medical Record Number (MRN) set to Temporary."
+
 
 #: senaite/patient/content/patient.py:108
 msgid "label_patient_mrn"

--- a/src/bes/nauru/lims/locales/senaite.patient.pot
+++ b/src/bes/nauru/lims/locales/senaite.patient.pot
@@ -50,7 +50,4 @@ msgstr ""
 
 #: senaite/patient/subscribers/analysisrequest.py:106
 
-
 #: senaite/patient/content/patient.py:108
-msgid "label_patient_mrn"
-msgstr "MRN"


### PR DESCRIPTION
## Description
This pull request updates all instances of "Hospital ID" to "Medical Records Number" for consistency and clarity.
Linked issue: #3 

## Current behavior
Hospital number is used to enter unique ID for each patient.

## Desired behavior
Replaced "Hospital ID" label/text with "Medical Records Number"

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
