### PR TITLE
Change sample Priorities

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changelog
 
 1.0.0 (Unreleased)
 ------------------
+- #24 Modify Sample Priority List
 - #21 Change "Hospital ID" to "Medical Records Number"
 - #20 Compatibility with core#2692 (Refactor sticker functionality)
 - #18 Display patient 'Date of Birth' in sticker "Code 39 40x28mm" 

--- a/src/bes/nauru/lims/config.py
+++ b/src/bes/nauru/lims/config.py
@@ -232,7 +232,6 @@ LOCATIONS = DisplayList((
 ))
 
 PRIORITIES = DisplayList((
-    ("1", _("Stat")),
-    ("3", _("Asap")),
+    ("1", _("Urgent")),
     ("5", _("Routine")),
 ))

--- a/src/bes/nauru/lims/locales/bes.nauru.lims.pot
+++ b/src/bes/nauru/lims/locales/bes.nauru.lims.pot
@@ -59,8 +59,6 @@ msgid "Analysis Template"
 msgstr ""
 
 #: bes.nauru.lims/src/bes/nauru/lims/config.py:236
-msgid "Asap"
-msgstr ""
 
 #: bes.nauru.lims/src/bes/nauru/lims/impress/reports/Default.pt:626
 msgid "Attachment for"

--- a/src/bes/nauru/lims/locales/en/LC_MESSAGES/bes.nauru.lims.po
+++ b/src/bes/nauru/lims/locales/en/LC_MESSAGES/bes.nauru.lims.po
@@ -56,8 +56,6 @@ msgid "Analysis Template"
 msgstr ""
 
 #: bes/nauru/lims/config.py:236
-msgid "Asap"
-msgstr ""
 
 #: bes/nauru/lims/impress/reports/Default.pt:626
 msgid "Attachment for"


### PR DESCRIPTION
## Description
This pull request modifies the list for sample priorities.
Linked issue: https://github.com/beyondessential/bes.nauru.lims/issues/13

## Current behavior
Current sample priority options are Stat, ASAP and Routine

## Desired behavior
Please add Urgent and remove Stat and ASAP as options

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
