### PR TITLE
Change of date format to dd/mm/yyyy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Changelog
 
 1.0.0 (Unreleased)
 ------------------
-
+- #24 Change date format
 - #27 Port check provisional analyses condition to bes.lims
 - #26 Compatibility with bes#14 (Merge PDF attachments into results report)
 - #25 Remove custom reflex machinery

--- a/src/bes/nauru/lims/impress/reports/Default.pt
+++ b/src/bes/nauru/lims/impress/reports/Default.pt
@@ -232,7 +232,7 @@
         <div class="alert alert-danger" tal:condition="model/is_invalid">
           <div i18n:translate="">This Sample has been invalidated due to erroneously published results</div>
           <tal:invalidreport tal:define="child python:model.getRetest()"
-                             tal:condition="child">
+                             tal:condition="python:child">
             <span i18n:translate="">This Sample has been replaced by</span>
             <a tal:attributes="href child/absolute_url"
                tal:content="child/getId"/>

--- a/src/bes/nauru/lims/locales/en/LC_MESSAGES/senaite.core.po
+++ b/src/bes/nauru/lims/locales/en/LC_MESSAGES/senaite.core.po
@@ -22,7 +22,7 @@ msgstr ""
 #. ${b} ${d}, ${Y} ${I}:${M} ${p}
 #: ./TranslationServiceTool.py
 msgid "date_format_long"
-msgstr "${m}/${d}/${Y} ${H}:${M}:${S}"
+msgstr "${d}/${m}/${Y} ${H}:${M}"
 
 #. The variables used here are the same as used in the strftime formating.
 #. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
@@ -32,13 +32,13 @@ msgstr "${m}/${d}/${Y} ${H}:${M}:${S}"
 #. ${b} ${d}, ${Y}
 #: ./TranslationServiceTool.py
 msgid "date_format_short"
-msgstr "${m}/${d}/${Y}"
+msgstr "${d}/${m}/${Y}"
 
 #. Date format used with the datepicker jqueryui plugin.
 #. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
 #. Default: "mm/dd/yy"
 msgid "date_format_short_datepicker"
-msgstr "mm/dd/yy"
+msgstr "dd/mm/yy"
 
 #. Default: "'Min' and 'Max' values indicate a valid results range. Any result outside this results range will raise an alert.<br/>'Min warn' and 'Max warn' values indicate a shoulder range. Any result outside the results range but within the shoulder range will raise a less severe alert.<br/>If the result is out of range, the value set for '&lt; Min' or '&gt; Max' will be displayed in lists and results reports instead of the real result. In such case, the value set for 'Out of range comment' will be displayed in results report as well"
 #: bika/lims/content/analysisspec.py:91

--- a/src/bes/nauru/lims/locales/senaite.core.pot
+++ b/src/bes/nauru/lims/locales/senaite.core.pot
@@ -22,7 +22,7 @@ msgstr ""
 #. ${b} ${d}, ${Y} ${I}:${M} ${p}
 #: ./TranslationServiceTool.py
 msgid "date_format_long"
-msgstr "${m}/${d}/${Y} ${H}:${M}:${S}"
+msgstr "${d}/${m}/${Y} ${H}:${M}:${S}"
 
 #. The variables used here are the same as used in the strftime formating.
 #. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
@@ -32,13 +32,13 @@ msgstr "${m}/${d}/${Y} ${H}:${M}:${S}"
 #. ${b} ${d}, ${Y}
 #: ./TranslationServiceTool.py
 msgid "date_format_short"
-msgstr "${m}/${d}/${Y}"
+msgstr "${d}/${m}/${Y}"
 
 #. Date format used with the datepicker jqueryui plugin.
 #. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
 #. Default: "mm/dd/yy"
 msgid "date_format_short_datepicker"
-msgstr "mm/dd/yy"
+msgstr "dd/mm/yy"
 
 #. Default: "'Min' and 'Max' values indicate a valid results range. Any result outside this results range will raise an alert.<br/>'Min warn' and 'Max warn' values indicate a shoulder range. Any result outside the results range but within the shoulder range will raise a less severe alert.<br/>If the result is out of range, the value set for '&lt; Min' or '&gt; Max' will be displayed in lists and results reports instead of the real result. In such case, the value set for 'Out of range comment' will be displayed in results report as well"
 #: bika/lims/content/analysisspec.py:91


### PR DESCRIPTION
## Description
This Pull Request changes the format of the date from mm/dd/yyyy to dd/mm/yyyy

Linked issue: https://github.com/beyondessential/bes.nauru.lims/issues/14

## Current behavior
Date shows in US format MM/DD/YYYY

## Desired behavior
Date should be shown in standard date format of DD/MM/YYYY

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
