### PR TITLE
Fix error on results report generation of an invalidated sample

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Changelog
 
 1.0.0 (Unreleased)
 ------------------
-
+- #30 Fix error on results report generation of an invalidated sample
 - #27 Port check provisional analyses condition to bes.lims
 - #26 Compatibility with bes#14 (Merge PDF attachments into results report)
 - #25 Remove custom reflex machinery

--- a/src/bes/nauru/lims/impress/reports/Default.pt
+++ b/src/bes/nauru/lims/impress/reports/Default.pt
@@ -232,7 +232,7 @@
         <div class="alert alert-danger" tal:condition="model/is_invalid">
           <div i18n:translate="">This Sample has been invalidated due to erroneously published results</div>
           <tal:invalidreport tal:define="child python:model.getRetest()"
-                             tal:condition="child">
+                             tal:condition="python:child">
             <span i18n:translate="">This Sample has been replaced by</span>
             <a tal:attributes="href child/absolute_url"
                tal:content="child/getId"/>


### PR DESCRIPTION
## Description
This Pull Request fixes an error that arises when generating a results report for an invalidated sample

Linked issue: https://github.com/beyondessential/bes.nauru.lims/issues/29

## Current behavior
```
Error: The container has no security assertions.  Access to 'mode' of (Field MedicalRecordNumber(temporaryidentifier:rw)) denied.

 - Expression: "python:'view' in widget.modes and 'r' in field.mode and field.checkPermission('r',here)"
 - Filename:   ... te/core/skins/senaite_templates/senaite_widgets/field.pt
 - Location:   (line 29: col 21)
 - Source:     ... python:'view' in widget.modes and 'r' in field.mode and field.checkPermission('r',here) ...
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Expression: "context/senaite_widgets/field/macros/base_view"
 - Filename:   ... te/core/skins/senaite_templates/senaite_widgets/field.pt
 - Location:   (line 71: col 38)
 - Source:     ... se-macro="context/senaite_widgets/field/macros/base_view" />
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Expression: "field_macro"
 - Filename:   ... te.core/src/senaite/core/skins/senaite_templates/base.pt
 - Location:   (line 36: col 42)
 - Source:     <metal:use_field use-macro="field_macro" />
                                           ^^^^^^^^^^^
 - Expression: "body_macro"
 - Filename:   ... re/src/senaite/core/skins/senaite_templates/base_view.pt
 - Location:   (line 86: col 35)
 - Source:     <metal:use_body use-macro="body_macro" />
                                          ^^^^^^^^^^
 - Expression: "provider:plone.abovecontentbody"
 - Filename:   ... te/core/browser/main_template/templates/main_template.pt
 - Location:   (line 132: col 84)
 - Source:     ... 
                                     ^
 - Expression: "context/main_template/macros/master"
 - Filename:   ... re/src/senaite/core/skins/senaite_templates/base_view.pt
 - Location:   (line 12: col 23)
 - Source:     ... etal:use-macro="context/main_template/macros/master"
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Expression: "child"
 - Filename:   ... bes.fnu.lims/src/bes/fnu/lims/impress/reports/Default.pt
 - Location:   (line 235: col 44)
 - Source:     tal:condition="child">
                              ^^^^^
 - Arguments:  repeat: <Products.PageTemplates.engine.RepeatDictWrapper object at 0x7f65accdc7d0>
               template: <FSPageTemplate at /senaite/base_view used for /senaite/clients/client-1/CDS25A044R1>
               modules: <Products.PageTemplates.ZRPythonExpr._SecureModuleImporter object at 0x7f65bd161f90>
               here: <AnalysisRequest at /senaite/clients/client-1/CDS25A044R1>
               user: <PropertiedUser 'admin'>
               nothing: None
               target_language: None
               container: <PloneSite at /senaite>
               root: <Application at >
               request: <WSGIRequest, URL=http://localhost:9090/senaite/samples/ajax_publish/render_reports>
               traverse_subpath: []
               default: <DEFAULT>
               loop: {u'field': <Products.PageTemplates.engine.RepeatItem object at 0x7f65a94c6050>, u'ref': <Products.PageTemplates.engine.RepeatItem object at 0x7f65aec78890>, u'idx': <Products.PageTemplates.engine.RepeatItem object at 0x7f65a97a46d0>, u'record': <Products.PageTemplates.engine.RepeatItem object at 0x7f65a94c2590>}
               context: <AnalysisRequest at /senaite/clients/client-1/CDS25A044R1>
               translate: <function translate at 0x7f65a90bbb50>
               macroname: u'master'
               options: {'args': ()}
               attrs: {}
```

## Desired behavior
No error while publishing an invalidated sample

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
