### PR TITLE
Add astm folder to the repository

### DIFF
--- a/src/bes/nauru/lims/astm/__init__.py
+++ b/src/bes/nauru/lims/astm/__init__.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of PALAU.LIMS.
+# This file is part of BES.NAURU.LIMS.
 #
-# PALAU.LIMS is free software: you can redistribute it and/or modify it under
+# BES.NAURU.LIMS is free software: you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free Software
 # Foundation, version 2.
 #

--- a/src/bes/nauru/lims/astm/__init__.py
+++ b/src/bes/nauru/lims/astm/__init__.py
@@ -1,0 +1,215 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of PALAU.LIMS.
+#
+# PALAU.LIMS is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2023-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from bika.lims import api
+from bika.lims.workflow import doActionFor
+from plone.memoize.instance import memoize
+from senaite.core.api import dtime
+from senaite.core.astm.importer import ASTMImporter as Base
+
+ALLOWED_SAMPLE_STATES = ["sample_received"]
+
+ALLOWED_ANALYSIS_STATES = ["unassigned", "assigned"]
+
+DL_OPERANDS = ["<", ">"]
+
+
+class ASTMBaseImporter(Base):
+    """Basic ASTM results importer
+    """
+
+    def get_sender(self):
+        """Return the instrument name, serial and version
+
+        :returns: Tuple of instrument name, serial, version
+        """
+        name, serial, version = super(ASTMBaseImporter, self).get_sender()
+        return name.strip(), serial.strip(), version.strip()
+
+    @property
+    @memoize
+    def analyses_by_keyword(self):
+        """Gets the analyses of the sample that are suitable for results input,
+        grouped by keyword. Note that for a single keyword, more than one
+        analysis can exist. Thus, a list for each keyword is returned
+        """
+        if not self.sample:
+            return {}
+
+        by_keyword = {}
+        brains = self.sample.getAnalyses(review_state=ALLOWED_ANALYSIS_STATES)
+        for brain in brains:
+            obj = api.get_object(brain)
+            keyword = obj.getKeyword()
+            by_keyword.setdefault(keyword, []).append(obj)
+        return by_keyword
+
+    @property
+    def keywords_mapping(self):
+        return dict()
+
+    def import_data(self):
+        """Import data
+        """
+        if not self.instrument:
+            return self.log("Cannot import results, instrument not found")
+
+        if not self.sample:
+            return self.log("Cannot import results, sample not found")
+
+        # check sample status is valid
+        state = api.get_review_status(self.sample)
+        if state not in ALLOWED_SAMPLE_STATES:
+            return self.log("Cannot import results, sample state: %s" % state)
+
+        # get the suitable analyses of the sample, grouped by keyword
+        if not self.analyses_by_keyword:
+            sample_id = api.get_id(self.sample)
+            return self.log("Cannot import results, no analyses left for "
+                            "sample %s" % sample_id)
+
+        # iterate over astm results and try to import them
+        attach = False
+        for result in self.get_results():
+            imported = self.import_result(result)
+            if imported:
+                attach = True
+
+        # create a new attachment with the message contents
+        if attach:
+            sender = self.get_sender()
+            filename = "%s.txt" % "_".join(sender)
+            attachment = self.create_attachment(
+                self.sample.getClient(), self.message, filename=filename
+            )
+            attachments = self.sample.getAttachment()
+            if attachment not in attachments:
+                attachments.append(attachment)
+                self.sample.setAttachment(attachments)
+
+    def get_analyses(self, term):
+        """Returns analyses from the current sample for the given term
+        """
+        analyses = []
+        # TODO Use a fieldset in Instrument instead of an instance property
+        keywords = self.keywords_mapping.get(term, [term])
+        if not isinstance(keywords, (list, tuple)):
+            keywords = [keywords]
+        for keyword in keywords:
+            ans = self.analyses_by_keyword.get(keyword, [])
+            analyses.extend(ans)
+        return list(set(analyses))
+
+    def get_captured_date(self, record):
+        return record.get("completed_at")
+
+    def get_test_id(self, record):
+        test_id = record.get("test") or ""
+        return test_id.strip()
+
+    def get_test_result(self, record):
+        value = record.get("value") or ""
+        return value.strip()
+
+    def get_test_units(self, record):
+        units = record.get("units") or ""
+        return units.strip()
+
+    def get_detection_limit_operand(self, record):
+        """Returns the detection limit operand ('<' or '>') if present in the
+        result record, unless already included in the result value
+        """
+        flag = record.get("abnormal_flag") or ""
+        if flag in DL_OPERANDS:
+            return flag
+        return ""
+
+    def import_result(self, record):
+        """Tries to import the result (ASTM) for this sample
+        """
+        value = self.get_test_result(record)
+        if not value:
+            # skip empty results
+            return False
+
+        param = self.get_test_id(record)
+        if not param:
+            # skip no parameter found
+            return False
+
+        captured = self.get_captured_date(record)
+        captured = dtime.to_DT(captured)
+        if not captured:
+            # skip no capture date found
+            return False
+
+        units = self.get_test_units(record)
+
+        sample_id = api.get_id(self.sample)
+
+        # try to resolve the keyword counterpart
+        analyses = self.get_analyses(param)
+        if not analyses:
+            # skip, no analyses found for this keyword
+            self.log("No analysis found for sample %s and parameter %s" %
+                     (sample_id, param))
+            return False
+
+        if len(analyses) > 1:
+            # skip, more than one analysis found
+            self.log("More than one analysis found for sample %s and "
+                     "parameter %s" % (sample_id, param))
+            return False
+
+        # resolve the basic settings of the analysis
+        analysis = analyses[0]
+        result_type = "string"
+        if api.is_floatable(value):
+            value = api.to_float(value)
+            result_type = "numeric"
+
+        # purge analysis
+        # TODO Allow to configure this in a fieldset in Instrument
+        analysis.setResultOptions([])
+        analysis.setResultType(result_type)
+        analysis.setUnitChoices([])
+        analysis.setDetectionLimitOperand("")
+        analysis.setAllowManualUncertainty(False)
+
+        dl_operand = self.get_detection_limit_operand(record)
+        if dl_operand:
+            # We do want to store the detection limit, even if the manual
+            # detection limit for the analysis is set to False
+            analysis.setAllowManualDetectionLimit(True)
+            analysis.setDetectionLimitOperand(dl_operand)
+
+        # set the result, capture date and unit
+        analysis.setResult(value)
+        analysis.setResultCaptureDate(captured)
+        analysis.setUnit(units)
+
+        # submit
+        doActionFor(analysis, "submit")
+
+        # report to the import log
+        self.log("Imported result for sample %s and test %s: %s %s"
+                 % (sample_id, param, value, units))
+
+        return True

--- a/src/bes/nauru/lims/astm/cepheid/configure.zcml
+++ b/src/bes/nauru/lims/astm/cepheid/configure.zcml
@@ -1,0 +1,6 @@
+<configure xmlns="http://namespaces.zope.org/zope">
+
+  <!-- Chepeid's GeneXpert -->
+  <adapter name="GeneXpert" factory=".genexpert.ASTMImporter"/>
+
+</configure>

--- a/src/bes/nauru/lims/astm/cepheid/genexpert.py
+++ b/src/bes/nauru/lims/astm/cepheid/genexpert.py
@@ -1,0 +1,240 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of PALAU.LIMS.
+#
+# PALAU.LIMS is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2023-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+import collections
+
+from bika.lims import api
+from palau.lims.astm import ASTMBaseImporter as Base
+
+# 4. test_id:             Chlamydia       Gonorrhea     HBV-VL
+# 5. test_name:           Xpert CT_NG     Xpert CT_NG   Xpert HBV Viral Load
+# 6. test_version:        3               3             1
+# 7. analyte_name         CT              NG
+# 8. complementary_name
+
+KEYWORDS_MAPPING = (
+    # Tuple of (instrument_parameter, (service_keywords))
+    # R|1|^CTNG^^Chlamydia^Xpert CT_NG^3^CT^|NOT DETECTED^||
+    ("Chlamydia", ["Chlamydia"]),
+    ("CT", ["Chlamydia"]),
+    # R|11|^CTNG^^Gonorrhea^Xpert CT_NG^3^NG^|NOT DETECTED^||
+    ("Gonorrhea", ["Gonorrhea"]),
+    ("NG", ["Gonorrhea"]),
+    # R|1|^^^HBV-VL^Xpert HBV Viral Load^1^^|^22.21|IU/mL|
+    ("HBV-VL", ["HBV-VL"]),
+    # R|1|^^^HCV-VL^Xpert_HCV Viral Load^1^^|NOT DETECTED^|IU/mL|
+    ("HCV-VL", ["HCV-VL"]),
+    # R|1|^^^HIV-VL^Xpert_HIV-1 Viral Load^1^^|^47473.65|copies/mL|
+    ("HIV-VL", ["HIV-VL"]),
+    # R|1|^XpertRES^^XpertCov^Xpress SARS-CoV-2_Flu_RSV plus^1^SARS-CoV-2^|NEGATIVE^||
+    ("XpertCov", ["XpertCov", "COVID-RT-PCR", "COVID-RDT"]),
+    ("SARS-CoV-2", ["XpertCov", "COVID-RT-PCR", "COVID-RDT"]),
+    # R|8|^XpertRES^^XpertFluA^Xpress SARS-CoV-2_Flu_RSV plus^1^Flu A^|NEGATIVE^||
+    ("XpertFluA", ["XpertFluA"]),
+    ("Flu A", ["XpertFluA"]),
+    # R|18|^XpertRES^^XpertFluB^Xpress SARS-CoV-2_Flu_RSV plus^1^Flu B^|NEGATIVE^||
+    ("XpertFluB", ["XpertFluB"]),
+    ("Flu B", ["XpertFluB"]),
+    # R|25|^XpertRES^^XpertRSV^Xpress SARS-CoV-2_Flu_RSV plus^1^RSV^|NEGATIVE^||
+    ("XpertRSV", ["XpertRSV"]),
+    ("RSV", ["XpertRSV"]),
+    # R|1|^X-Carba^^IMP^Xpert_Carba-R^1^IMP^|NOT DETECTED^||
+    ("IMP", []),
+    # R|8|^X-Carba^^VIM^Xpert_Carba-R^1^VIM^|NOT DETECTED^||
+    ("VIM", []),
+    # R|15|^X-Carba^^NDM^Xpert_Carba-R^1^NDM^|NOT DETECTED^||
+    ("NDM", []),
+    # R|22|^X-Carba^^KPC^Xpert_Carba-R^1^KPC^|NOT DETECTED^||
+    ("KPC", []),
+    # R|29|^X-Carba^^OXA48^Xpert_Carba-R^1^OXA48^|NOT DETECTED^||
+    ("OXA48", []),
+)
+
+
+class ASTMImporter(Base):
+    """Results importer for Cepheid GeneXpert
+    """
+
+    @property
+    def keywords_mapping(self):
+        return dict(KEYWORDS_MAPPING)
+
+    def get_sender(self):
+        """Return the instrument name, serial and version
+
+        :returns: Tuple of instrument name, serial, version
+        """
+        header = self.get_header()
+        if not header:
+            return None
+        sender = header.get("sender", {})
+        name = sender.get("name", "")
+        serial = sender.get("id", "")
+        version = sender.get("software_version", "")
+        return name, serial, version
+
+    def get_patient(self):
+        """Returns the (P)atient record of this astm message
+        """
+        patients = self.get_patients()
+        if len(patients) != 1:
+            return {}
+        return patients[0]
+
+    def get_sample_id(self, default=None):
+        """Get the Sample ID
+        """
+        sample_id = super(ASTMImporter, self).get_sample_id(default=default)
+        if sample_id:
+            return sample_id
+
+        # Fallback to patient record's practice_id
+        patient = self.get_patient()
+        if not patient:
+            return default
+
+        # Fallback to Patient ID 1
+        pid = patient.get("id")
+        if pid:
+            return pid
+
+        # Fallback to Patient ID 2 (Practice-assigned ID)
+        pid = patient.get("practice_id")
+        if pid:
+            return pid
+
+        return default
+
+    def is_main_result(self, record):
+        """Returns whether the result record is a main result
+        """
+        test = record.get("test")
+        if not test:
+            return False
+
+        # must have both name and version
+        name = test.get("test_name")
+        version = test.get("test_version")
+        if not all([name, version]):
+            return False
+
+        # and complementary name must be empty
+        complementary = test.get("complementary_name")
+        if complementary:
+            return False
+
+        return True
+
+    def get_test_key(self, result):
+        """Returns the test key used for grouping tests, that is made of the
+        concatenation of the panel_id + test_id
+        """
+        test = result.get("test") or {}
+        panel_id = test.get("panel_id") or ""
+        test_id = test.get("test_id") or ""
+        return ".".join([panel_id, test_id])
+
+    def group_by_test(self, results):
+        """Groups the ASTM results by test
+        """
+        groups = collections.OrderedDict()
+        for result in results:
+            key = self.get_test_key(result)
+            groups.setdefault(key, []).append(result)
+        return groups
+
+    def to_interim(self, result):
+        """Converts the result to an interim-compliant dict
+        """
+        test = result.get("test") or {}
+        analyte_name = test.get("analyte_name")
+        complementary_name = test.get("complementary_name")
+        parts = list(filter(None, [analyte_name, complementary_name]))
+        if not parts:
+            return None
+
+        result_value = self.get_test_result(result)
+        result_type = "" if api.is_floatable(result) else "string"
+        return {
+            "keyword": "_".join(parts),
+            "title": ".".join(parts),
+            "value": result_value,
+            "choices": [],
+            "result_type": result_type,
+            "allow_empty": True,
+            "unit": self.get_test_units(result),
+            "hidden": False,
+            "wide": False,
+        }
+
+    def get_results(self):
+        """Return the (R)esult records that are considered as main results
+        """
+        results = super(ASTMImporter, self).get_results()
+
+        # extract main results
+        main_results = [r for r in results if self.is_main_result(r)]
+
+        # extract secondary (analyte and complementary) results
+        sec_results = [r for r in results if r not in main_results]
+
+        # group secondary results by test
+        sec_by_test = self.group_by_test(sec_results)
+
+        # assign secondary results to main result
+        for result in main_results:
+
+            # get the test full key
+            key = self.get_test_key(result)
+
+            # get the analyte and complementary results
+            secondaries = sec_by_test.get(key)
+            for secondary in secondaries:
+                # convert to an interim-like record
+                interim = self.to_interim(secondary)
+                if not interim:
+                    continue
+                # add as an interim result field
+                result.setdefault("interims", []).append(interim)
+
+        # return the main results (with interims)
+        return main_results
+
+    def get_test_result(self, record):
+        """Returns the qualitative or quantitative result of the result record
+        """
+        value = record.get("value") or {}
+        qualitative = value.get("qualitative_result")
+        if qualitative:
+            return qualitative
+        return value.get("quantitative_result") or ""
+
+    def get_test_id(self, record):
+        """Returns the test ID from the given results record
+        """
+        test = record.get("test") or {}
+
+        # give priority to the analyte_name over test_id
+        analyte_name = test.get("analyte_name")
+        if analyte_name:
+            return analyte_name
+
+        # fall-back to test_id
+        return test.get("test_id") or ""

--- a/src/bes/nauru/lims/astm/cepheid/genexpert.py
+++ b/src/bes/nauru/lims/astm/cepheid/genexpert.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of PALAU.LIMS.
+# This file is part of BES.NAURU.LIMS.
 #
-# PALAU.LIMS is free software: you can redistribute it and/or modify it under
+# BES.NAURU.LIMS is free software: you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free Software
 # Foundation, version 2.
 #
@@ -21,7 +21,7 @@
 import collections
 
 from bika.lims import api
-from palau.lims.astm import ASTMBaseImporter as Base
+from bes.nauru.lims.astm import ASTMBaseImporter as Base
 
 # 4. test_id:             Chlamydia       Gonorrhea     HBV-VL
 # 5. test_name:           Xpert CT_NG     Xpert CT_NG   Xpert HBV Viral Load

--- a/src/bes/nauru/lims/astm/configure.zcml
+++ b/src/bes/nauru/lims/astm/configure.zcml
@@ -1,0 +1,7 @@
+<configure xmlns="http://namespaces.zope.org/zope">
+
+  <!-- Package includes -->
+  <include package=".siemens" />
+  <include package=".sysmex" />
+
+</configure>

--- a/src/bes/nauru/lims/astm/siemens/__init__.py
+++ b/src/bes/nauru/lims/astm/siemens/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of PALAU.LIMS.
+#
+# PALAU.LIMS is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2023-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.

--- a/src/bes/nauru/lims/astm/siemens/__init__.py
+++ b/src/bes/nauru/lims/astm/siemens/__init__.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of PALAU.LIMS.
+# This file is part of BES.NAURU.LIMS.
 #
-# PALAU.LIMS is free software: you can redistribute it and/or modify it under
+# BES.NAURU.LIMS is free software: you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free Software
 # Foundation, version 2.
 #

--- a/src/bes/nauru/lims/astm/siemens/configure.zcml
+++ b/src/bes/nauru/lims/astm/siemens/configure.zcml
@@ -1,0 +1,6 @@
+<configure xmlns="http://namespaces.zope.org/zope">
+
+  <!-- SIEMENS DCA Vantage -->
+  <adapter name="DCA VANTAGE" factory=".dcavantage.ASTMImporter"/>
+
+</configure>

--- a/src/bes/nauru/lims/astm/siemens/dcavantage.py
+++ b/src/bes/nauru/lims/astm/siemens/dcavantage.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of PALAU.LIMS.
+#
+# PALAU.LIMS is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2023-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from palau.lims.astm import ASTMBaseImporter as Base
+
+
+KEYWORDS_MAPPING = (
+    # Tuple of (instrument_parameter, (service_keywords))
+    ("Crt", ["creat", "CREAT_A", "UCREA", "CREAT_V"]),
+    ("Alb", ["Alb", "UALB"]),
+    ("Ratio", ["MALB"]),
+    ("HbA1c", ["HbA1c"]),
+)
+
+
+class ASTMImporter(Base):
+    """Results importer for SIEMENS DCA Vantage Analyzer
+    """
+
+    @property
+    def keywords_mapping(self):
+        return dict(KEYWORDS_MAPPING)
+
+    def get_patient(self):
+        patients = self.get_patients()
+        if len(patients) != 1:
+            return {}
+        return patients[0]
+
+    def get_sample_id(self, default=None):
+        """Get the Sample ID
+        """
+        sample_id = super(ASTMImporter, self).get_sample_id(default=default)
+        if sample_id:
+            return sample_id
+
+        # Fallback to patient record's practice_id
+        patient = self.get_patient()
+        if not patient:
+            return default
+
+        sid = patient.get("practice_id")
+        if not sid:
+            return default
+
+        return sid
+
+    def get_test_id(self, record):
+        """Returns the test ID from the given results record
+        """
+        test = record.get("test") or {}
+        param = test.get("parameter") or ""
+        return param.strip()
+
+    def get_captured_date(self, record):
+        """Returns the date when the result was captured
+        """
+        return record.get("started_at")

--- a/src/bes/nauru/lims/astm/siemens/dcavantage.py
+++ b/src/bes/nauru/lims/astm/siemens/dcavantage.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of PALAU.LIMS.
+# This file is part of BES.NAURU.LIMS.
 #
-# PALAU.LIMS is free software: you can redistribute it and/or modify it under
+# BES.NAURU.LIMS is free software: you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free Software
 # Foundation, version 2.
 #
@@ -18,7 +18,7 @@
 # Copyright 2023-2025 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from palau.lims.astm import ASTMBaseImporter as Base
+from bes.nauru.lims.astm import ASTMBaseImporter as Base
 
 
 KEYWORDS_MAPPING = (

--- a/src/bes/nauru/lims/astm/sysmex/__init__.py
+++ b/src/bes/nauru/lims/astm/sysmex/__init__.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of PALAU.LIMS.
+#
+# PALAU.LIMS is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2023-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from palau.lims.astm import ASTMBaseImporter as Base
+
+
+class SysmexASTMImporter(Base):
+    """Basic ASTM results importer for Sysmex instruments
+    """
+
+    def get_sample_id(self, default=None):
+        """Get the Sample ID. For Sysmex, the 'sample_id' astm field from
+        (O)rder record is not used, but 'instrument specimen id'
+        """
+        order = self.get_order()
+        if not order:
+            return default
+        instrument = order.get("instrument")
+        if not instrument:
+            return default
+        sid = instrument.get("sample_id").strip()
+        if not sid:
+            return default
+        return sid
+
+    def get_test_id(self, record):
+        """Returns the test ID from the given results record
+        """
+        test = record.get("test") or {}
+        param = test.get("parameter") or ""
+        return param.strip()

--- a/src/bes/nauru/lims/astm/sysmex/__init__.py
+++ b/src/bes/nauru/lims/astm/sysmex/__init__.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of PALAU.LIMS.
+# This file is part of BES.NAURU.LIMS.
 #
-# PALAU.LIMS is free software: you can redistribute it and/or modify it under
+# BES.NAURU.LIMS is free software: you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free Software
 # Foundation, version 2.
 #
@@ -18,7 +18,7 @@
 # Copyright 2023-2025 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from palau.lims.astm import ASTMBaseImporter as Base
+from bes.nauru.lims.astm import ASTMBaseImporter as Base
 
 
 class SysmexASTMImporter(Base):

--- a/src/bes/nauru/lims/astm/sysmex/configure.zcml
+++ b/src/bes/nauru/lims/astm/sysmex/configure.zcml
@@ -1,0 +1,10 @@
+<configure xmlns="http://namespaces.zope.org/zope">
+
+  <!-- Sysmex XN-550 (sender name comes with 4 leading whitespaces -->
+  <adapter name="XN-550" factory=".xn550.ASTMImporter"/>
+  <adapter name="    XN-550" factory=".xn550.ASTMImporter"/>
+
+  <!-- Sysmex XP-100 -->
+  <adapter name="XP-100" factory=".xp100.ASTMImporter"/>
+
+</configure>

--- a/src/bes/nauru/lims/astm/sysmex/xn550.py
+++ b/src/bes/nauru/lims/astm/sysmex/xn550.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of PALAU.LIMS.
+# This file is part of BES.NAURU.LIMS.
 #
-# PALAU.LIMS is free software: you can redistribute it and/or modify it under
+# BES.NAURU.LIMS is free software: you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free Software
 # Foundation, version 2.
 #
@@ -18,7 +18,7 @@
 # Copyright 2023-2025 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from palau.lims.astm.sysmex import SysmexASTMImporter
+from bes.nauru.lims.astm.sysmex import SysmexASTMImporter
 from senaite.core.interfaces import IASTMImporter
 from senaite.core.interfaces import ISenaiteCore
 from zope.component import adapter

--- a/src/bes/nauru/lims/astm/sysmex/xn550.py
+++ b/src/bes/nauru/lims/astm/sysmex/xn550.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of PALAU.LIMS.
+#
+# PALAU.LIMS is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2023-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from palau.lims.astm.sysmex import SysmexASTMImporter
+from senaite.core.interfaces import IASTMImporter
+from senaite.core.interfaces import ISenaiteCore
+from zope.component import adapter
+from zope.interface import implementer
+from zope.interface import Interface
+
+
+KEYWORDS_MAPPING = (
+    # Tuple of (instrument_parameter, (service_keywords))
+    ("BASO#", ["BASO"]),
+    ("BASO%", ["Basophils"]),
+    ("EO#", ["EO"]),
+    ("EO%", ["Eosinophils"]),
+    ("HCT", ["HCT"]),
+    ("HGB", ["Hb-"]),
+    ("IG#", ["IG"]),
+    ("IG%", ["ig"]),
+    ("LYMPH#", ["LYMPH"]),
+    ("LYMPH%", ["Lymphocytes"]),
+    ("MCH", ["MCH"]),
+    ("MCHC", ["MCHC"]),
+    ("MCV", ["MCV"]),
+    ("MONO#", ["MONO"]),
+    ("MONO%", ["Monocytes"]),
+    ("MPV", ["MPV"]),
+    ("NEUT#", ["NEUT"]),
+    ("NEUT%", ["Neutrophils"]),
+    ("PLT", ["PLT"]),
+    ("RBC", ["RBC_BF", "Red-CC", "RBC", "RPBC"]),
+    ("RET#", ["Reticulocyte"]),
+    ("WBC", ["WBC_BF", "White-CC", "WBC", "PWBC", "WC"]),
+)
+
+
+@adapter(Interface, Interface, ISenaiteCore)
+@implementer(IASTMImporter)
+class ASTMImporter(SysmexASTMImporter):
+    """ASTM results importer for Sysmex XN-550
+    """
+
+    @property
+    def keywords_mapping(self):
+        return dict(KEYWORDS_MAPPING)

--- a/src/bes/nauru/lims/astm/sysmex/xp100.py
+++ b/src/bes/nauru/lims/astm/sysmex/xp100.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of PALAU.LIMS.
+    # This file is part of BES.NAURU.LIMS.
 #
-# PALAU.LIMS is free software: you can redistribute it and/or modify it under
+# BES.NAURU.LIMS is free software: you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free Software
 # Foundation, version 2.
 #
@@ -18,7 +18,7 @@
 # Copyright 2023-2025 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from palau.lims.astm.sysmex import SysmexASTMImporter
+from bes.nauru.lims.astm.sysmex import SysmexASTMImporter
 from senaite.core.interfaces import IASTMImporter
 from senaite.core.interfaces import ISenaiteCore
 from zope.component import adapter

--- a/src/bes/nauru/lims/astm/sysmex/xp100.py
+++ b/src/bes/nauru/lims/astm/sysmex/xp100.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of PALAU.LIMS.
+#
+# PALAU.LIMS is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2023-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from palau.lims.astm.sysmex import SysmexASTMImporter
+from senaite.core.interfaces import IASTMImporter
+from senaite.core.interfaces import ISenaiteCore
+from zope.component import adapter
+from zope.interface import implementer
+from zope.interface import Interface
+
+
+KEYWORDS_MAPPING = (
+    # Tuple of (instrument_parameter, (service_keywords))
+    ("HCT", ["HCT"]),
+    ("HGB", ["Hb-"]),
+    ("LYM#", ["LYMPH"]),
+    ("LYM%", ["Lymphocytes"]),
+    ("MCH", ["MCH"]),
+    ("MCHC", ["MCHC"]),
+    ("MCV", ["MCV"]),
+    ("MPV", ["MPV"]),
+    ("NEUT#", ["NEUT"]),
+    ("NEUT%", ["Neutrophils"]),
+    ("RBC", ["RBC_BF", "Red-CC", "RBC", "RPBC"]),
+    ("WBC", ["WBC_BF", "White-CC", "WBC", "PWBC", "WC"]),
+    ("MXD%", ["MXD"]),
+    ("MXD#", ["MXDA"]),
+)
+
+
+@adapter(Interface, Interface, ISenaiteCore)
+@implementer(IASTMImporter)
+class ASTMImporter(SysmexASTMImporter):
+    """ASTM results importer for Sysmex XP-100
+    """
+
+    @property
+    def keywords_mapping(self):
+        return dict(KEYWORDS_MAPPING)

--- a/src/bes/nauru/lims/configure.zcml
+++ b/src/bes/nauru/lims/configure.zcml
@@ -17,6 +17,7 @@
 
   <!-- Package includes -->
   <include package=".adapters" />
+  <include package=".astm" />
   <include package=".behaviors" />
   <include package=".browser" />
   <include package=".catalog" />


### PR DESCRIPTION
## Description
ASTM folder is required for equipment interfacing.

Linked issue: https://github.com/beyondessential/bes.nauru.lims/issues/23

## Current behavior
ASTM folder is not part of the repository to interface with lab equipment.

## Desired behavior
ASTM folder is added for equipment interfacing.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
