### PR TITLE
Fix missing value for split_length subfield in ID Server

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.0.0 (Unreleased)
 ------------------
 
+- #45 Fix missing value for split_length subfield in ID Server
 - #42 Add ASTM Consumer for cobas® c 311 analyzer
 - #38 Enable self-verification of AST-like services and analyses
 - #24 Change date format to dd/mm/yyyy

--- a/src/bes/nauru/lims/config.py
+++ b/src/bes/nauru/lims/config.py
@@ -137,19 +137,19 @@ ID_FORMATTING = [
         "form": "{parent_ar_id}P{partition_count:01d}",
         "prefix": "analysisrequestpartition",
         "sequence_type": "",
-        "split-length": 1
+        "split_length": 2
     }, {
         "portal_type": "AnalysisRequestRetest",
         "form": "{parent_base_id}R{retest_count:01d}",
         "prefix": "analysisrequestretest",
         "sequence_type": "",
-        "split-length": 1
+        "split_length": 2
     }, {
         "portal_type": "AnalysisRequestSecondary",
         "form": "{parent_ar_id}S{secondary_count:01d}",
         "prefix": "analysisrequestsecondary",
         "sequence_type": "",
-        "split-length": 1
+        "split_length": 2
     }, {
         "portal_type": "Worksheet",
         "form": "WS{yymmdd}-{seq:02d}",

--- a/src/bes/nauru/lims/profiles/default/metadata.xml
+++ b/src/bes/nauru/lims/profiles/default/metadata.xml
@@ -6,7 +6,7 @@
   dependencies before installing this add-on own profile.
 -->
 <metadata>
-  <version>1001</version>
+  <version>1002</version>
 
   <!-- Be sure to install the following dependencies if not yet installed -->
   <dependencies>

--- a/src/bes/nauru/lims/upgrade/v01_00_000.zcml
+++ b/src/bes/nauru/lims/upgrade/v01_00_000.zcml
@@ -3,6 +3,18 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
+      title="Fix ID's split length for partition, retest and secondary samples"
+      description="
+        Updates the ID server's split_length parameter for the portal types
+        AnalysisRequestPartition, AnalysisRequestRetest and
+        AnalysisRequestSecondary
+      "
+      source="1001"
+      destination="1002"
+      handler=".v01_00_000.fix_split_length"
+      profile="bes.nauru.lims:default"/>
+
+  <genericsetup:upgradeStep
       title="Enable self-verification of AST-like services and analyses"
       description="Enable self-verification of AST-like services and analyses"
       source="1000"


### PR DESCRIPTION
## Description

This Pull Request fixes missing values in the `split_length` subfield for the portal types `AnalysisRequestPartition`, `AnalysisRequestRetest`, and `AnalysisRequestSecondary`. The issue was identified after the changes introduced in https://github.com/senaite/senaite.core/pull/2821

## Current behavior

Error when "Save" button is clicked in Setup because of missing values in ID server

## Desired behavior

Error when "Save" button is clicked in Setup because of missing values in ID server

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
